### PR TITLE
bump default version of joe's filter to publish additional modules

### DIFF
--- a/src/components/FilterSelector.tsx
+++ b/src/components/FilterSelector.tsx
@@ -33,7 +33,7 @@ const COMMON_FILTERS = [
   },
   {
     name: "Joe's Loot Filter for Persnickety Irons",
-    url: "https://raw.githubusercontent.com/typical-whack/loot-filters-modules/644908ddfbe28e0283896f1c51738dabe7762220/filter.json",
+    url: "https://raw.githubusercontent.com/typical-whack/loot-filters-modules/679554a14c69d0e5785f479138e47e0bb9e7582c/filter.json",
   },
 ];
 


### PR DESCRIPTION
added seeds, secondaries, and remains

+a bunch of tweaks

https://github.com/typical-whack/loot-filters-modules/compare/644908ddfbe28e0283896f1c51738dabe7762220..679554a14c69d0e5785f479138e47e0bb9e7582c