### PR TITLE
add example item field to style input

### DIFF
--- a/module-system-docs/site-testing-filters/single_style_filter.json
+++ b/module-system-docs/site-testing-filters/single_style_filter.json
@@ -15,7 +15,8 @@
                         "label": "Style Input Test",
                         "macroName": "STYLE_INPUT_TEST",
                         "description": "A style input with no default values",
-                        "default": {}
+                        "default": {},
+                        "exampleItem": "Example item"
                     }
                 ]
             },

--- a/src/components/Previews.tsx
+++ b/src/components/Previews.tsx
@@ -84,7 +84,7 @@ export const ItemMenuPreview: React.FC<{
                                     fontSize: '24px',
                                 }}
                             >
-                                {itemName}
+                                {input.exampleItem || itemName || 'Item Name'}
                             </span>
                         </div>
                     </div>
@@ -220,7 +220,7 @@ export const ItemLabelPreview: React.FC<{
                         fontFamily: fontFamily,
                     }}
                 >
-                    {itemName || 'Item Name'}
+                    {input.exampleItem || itemName || 'Item Name'}
                 </span>
             </div>
         </Box>

--- a/src/types/InputsSpec.ts
+++ b/src/types/InputsSpec.ts
@@ -129,4 +129,5 @@ export type StyleInput = Omit<FilterModuleInput<'style'>, 'default'> & {
         tileFillColor: ArgbHexColor
         tileHighlightColor: ArgbHexColor
     }
+    exampleItem?: string
 }


### PR DESCRIPTION
allows adding an example item to style inputs like:
```
{
    "type": "style",
    "label": "Style Input Test",
    "macroName": "STYLE_INPUT_TEST",
    "description": "A style input with no default values",
    "default": {},
    "exampleItem": "Example item"
}
```

![image](https://github.com/user-attachments/assets/427e6634-9b20-4657-9f13-a3d77deb21bc)
