### PR TITLE
fix text accent rendering and selector

### DIFF
--- a/src/components/Previews.tsx
+++ b/src/components/Previews.tsx
@@ -1,13 +1,7 @@
 import { Box, SxProps } from '@mui/material'
 import { useUiStore } from '../store/store'
 import { colors } from '../styles/MuiTheme'
-import {
-    FontType,
-    fontTypeFromOrdinal,
-    StyleInput,
-    TextAccent,
-    textAccentFromOrdinal,
-} from '../types/InputsSpec'
+import { fontFamilyFromFontType, StyleInput } from '../types/InputsSpec'
 import { UiFilterModule } from '../types/ModularFilterSpec'
 import { colorHexToRgbaCss } from '../utils/Color'
 import { StyleConfig } from './inputs/StyleInputHelpers'
@@ -128,19 +122,9 @@ export const ItemLabelPreview: React.FC<{
         activeConfig?.hideOverlay ?? input.default?.hideOverlay ?? false
 
     const fontType = activeConfig?.fontType ?? input.default?.fontType
-    const fontFamily =
-        fontTypeFromOrdinal(fontType) === FontType.NORMAL
-            ? 'RuneScapeSmall'
-            : fontTypeFromOrdinal(fontType) === FontType.BOLD
-              ? 'RuneScapeBold'
-              : fontTypeFromOrdinal(fontType) === FontType.LARGER
-                ? 'RuneScape'
-                : 'RuneScapeSmall'
+    const fontFamily = fontFamilyFromFontType(fontType)
 
-    const textAccentOrdinal =
-        activeConfig?.textAccent ?? input.default?.textAccent
-    const textAccent =
-        textAccentFromOrdinal(textAccentOrdinal) ?? TextAccent.SHADOW
+    const textAccent = activeConfig?.textAccent ?? input.default?.textAccent
 
     const textAccentColor =
         activeConfig?.textAccentColor ?? input.default?.textAccentColor
@@ -149,23 +133,28 @@ export const ItemLabelPreview: React.FC<{
         webkitTextStroke?: string
     } = {}
     switch (textAccent) {
-        case TextAccent.SHADOW:
-            textAccentStyle = {
-                textShadow: '1px 1px #000000',
-            }
-            break
-        case TextAccent.OUTLINE:
+        // Outline
+        case 2:
             textAccentStyle = {
                 WebkitTextStroke: `1px ${colorHexToRgbaCss(textAccentColor) ?? 'rgb(0,0,0,0)'}`,
             }
             break
-        case TextAccent.SHADOW_BOLD:
+        // None
+        case 3:
+            textAccentStyle = {}
+            break
+        // Shadow Bold
+        case 4:
             textAccentStyle = {
                 textShadow: '2px 2px #000000',
             }
             break
-        case TextAccent.NONE:
-            textAccentStyle = {}
+        // Shadow is default
+        case 1:
+        default:
+            textAccentStyle = {
+                textShadow: '1px 1px #000000',
+            }
             break
     }
 

--- a/src/components/inputs/ItemLabelColorPicker.tsx
+++ b/src/components/inputs/ItemLabelColorPicker.tsx
@@ -1,5 +1,6 @@
 import { Divider } from '@mui/material'
 import { useUiStore } from '../../store/store'
+import { colors } from '../../styles/MuiTheme'
 import {
     FontType,
     fontTypeFromOrdinal,
@@ -8,6 +9,7 @@ import {
     TextAccent,
     textAccentFromOrdinal,
     textAccentOrdinal,
+    uiSelectFromOrdinal
 } from '../../types/InputsSpec'
 import { UiFilterModule } from '../../types/ModularFilterSpec'
 import { ArgbHexColor } from '../../utils/Color'
@@ -15,7 +17,6 @@ import { ItemLabelPreview, ItemMenuPreview } from '../Previews'
 import { ColorPickerInput } from './ColorPicker'
 import { StyleConfig, StyleConfigKey } from './StyleInputHelpers'
 import { Option, UISelect } from './UISelect'
-import { colors } from '../../styles/MuiTheme'
 
 export const ItemLabelColorPicker: React.FC<{
     module: UiFilterModule
@@ -69,6 +70,9 @@ export const ItemLabelColorPicker: React.FC<{
             value: textAccentOrdinal(accent),
         })
     )
+
+    console.log(textAccentOptions)
+    console.log(activeConfig?.textAccent)
 
     return (
         <div
@@ -182,8 +186,9 @@ export const ItemLabelColorPicker: React.FC<{
                         (activeConfig?.textAccent === undefined ||
                             textAccentFromOrdinal(activeConfig.textAccent) ===
                                 TextAccent.NONE) &&
-                        (activeConfig?.textAccentColor !== undefined ||
-                            input.default?.textAccentColor !== undefined)
+                        (input.default?.textAccent === undefined ||
+                            textAccentFromOrdinal(input.default.textAccent) ===
+                                TextAccent.NONE)
                             ? 'Warning: Text accent color is set but text accent is None'
                             : undefined
                     }
@@ -197,14 +202,7 @@ export const ItemLabelColorPicker: React.FC<{
                     multiple={false}
                     freeSolo={false}
                     value={
-                        activeConfig?.textAccent !== undefined
-                            ? {
-                                  label: textAccentFromOrdinal(
-                                      activeConfig.textAccent
-                                  ),
-                                  value: activeConfig.textAccent,
-                              }
-                            : null
+                        uiSelectFromOrdinal(activeConfig?.textAccent) ?? uiSelectFromOrdinal(input.default?.textAccent)
                     }
                     onChange={(newValue) => {
                         if (newValue === null) {

--- a/src/components/inputs/ItemLabelColorPicker.tsx
+++ b/src/components/inputs/ItemLabelColorPicker.tsx
@@ -71,9 +71,6 @@ export const ItemLabelColorPicker: React.FC<{
         })
     )
 
-    console.log(textAccentOptions)
-    console.log(activeConfig?.textAccent)
-
     return (
         <div
             style={{

--- a/src/components/inputs/ItemLabelColorPicker.tsx
+++ b/src/components/inputs/ItemLabelColorPicker.tsx
@@ -3,13 +3,10 @@ import { useUiStore } from '../../store/store'
 import { colors } from '../../styles/MuiTheme'
 import {
     FontType,
-    fontTypeFromOrdinal,
-    fontTypeOrdinal,
+    fontType,
     StyleInput,
     TextAccent,
-    textAccentFromOrdinal,
-    textAccentOrdinal,
-    uiSelectFromOrdinal
+    textAccent,
 } from '../../types/InputsSpec'
 import { UiFilterModule } from '../../types/ModularFilterSpec'
 import { ArgbHexColor } from '../../utils/Color'
@@ -57,20 +54,24 @@ export const ItemLabelColorPicker: React.FC<{
         })
     }
 
-    const fontTypeOptions: Option<number>[] = Object.values(FontType).map(
-        (type) => ({
-            label: type.charAt(0).toUpperCase() + type.slice(1),
-            value: fontTypeOrdinal(type),
-        })
-    )
+    const fontTypeOptions: Option<FontType>[] = Object.keys(fontType)
+        .map((type) => type as unknown as FontType)
+        .map((type) => ({
+            label: fontType[type],
+            value: type,
+        }))
 
-    const textAccentOptions: Option<number>[] = Object.values(TextAccent).map(
-        (accent) => ({
-            label: accent.charAt(0).toUpperCase() + accent.slice(1),
-            value: textAccentOrdinal(accent),
-        })
-    )
+    const textAccentOptions: Option<TextAccent>[] = Object.keys(textAccent)
+        .map((accent) => accent as unknown as TextAccent)
+        .map((accent) => ({
+            label: textAccent[accent],
+            value: accent,
+        }))
 
+    console.log(typeof activeConfig.textAccent, typeof input.default.textAccent)
+    console.log(
+        (activeConfig.textAccent ?? input.default.textAccent) == 3 /* NONE */
+    )
     return (
         <div
             style={{
@@ -130,21 +131,25 @@ export const ItemLabelColorPicker: React.FC<{
                         label="Overlay Font Type"
                         multiple={false}
                         freeSolo={false}
-                        value={
-                            activeConfig?.fontType !== undefined
-                                ? {
-                                      label: fontTypeFromOrdinal(
-                                          activeConfig.fontType
-                                      ),
-                                      value: activeConfig.fontType,
-                                  }
-                                : null
-                        }
+                        value={{
+                            label: fontType[
+                                activeConfig.fontType ??
+                                    input.default.fontType ??
+                                    1 // Default to small
+                            ],
+                            value:
+                                activeConfig.fontType ??
+                                input.default.fontType ??
+                                1,
+                        }}
                         onChange={(newValue) => {
                             if (newValue === null) {
                                 updateStyleField('fontType', undefined)
                             } else {
-                                updateStyleField('fontType', newValue.value)
+                                updateStyleField(
+                                    'fontType',
+                                    newValue.value as FontType
+                                )
                             }
                         }}
                     />
@@ -180,12 +185,9 @@ export const ItemLabelColorPicker: React.FC<{
                     }
                     labelLocation={labelLocation}
                     helpText={
-                        (activeConfig?.textAccent === undefined ||
-                            textAccentFromOrdinal(activeConfig.textAccent) ===
-                                TextAccent.NONE) &&
-                        (input.default?.textAccent === undefined ||
-                            textAccentFromOrdinal(input.default.textAccent) ===
-                                TextAccent.NONE)
+                        (activeConfig.textAccent ?? input.default.textAccent) ==
+                            3 /* must be == not === idk why */ &&
+                        activeConfig.textAccentColor !== undefined
                             ? 'Warning: Text accent color is set but text accent is None'
                             : undefined
                     }
@@ -198,14 +200,25 @@ export const ItemLabelColorPicker: React.FC<{
                     label="Text Accent"
                     multiple={false}
                     freeSolo={false}
-                    value={
-                        uiSelectFromOrdinal(activeConfig?.textAccent) ?? uiSelectFromOrdinal(input.default?.textAccent)
-                    }
+                    value={{
+                        label: textAccent[
+                            activeConfig.textAccent ??
+                                input.default.textAccent ??
+                                1 // Default to shadow
+                        ],
+                        value:
+                            activeConfig.textAccent ??
+                            input.default.textAccent ??
+                            1, // Default to shadow
+                    }}
                     onChange={(newValue) => {
                         if (newValue === null) {
                             updateStyleField('textAccent', undefined)
                         } else {
-                            updateStyleField('textAccent', newValue.value)
+                            updateStyleField(
+                                'textAccent',
+                                newValue.value as TextAccent
+                            )
                         }
                     }}
                 />

--- a/src/types/InputsSpec.ts
+++ b/src/types/InputsSpec.ts
@@ -72,49 +72,35 @@ export type IncludeExcludeListInput = Omit<
     default: IncludeExcludeListInputDefaults
 }
 
-// Enum ordinal needs to match what is supported in the plugin
-export const textAccentFromOrdinal = (ordinal: number): TextAccent => {
-    return Object.values(TextAccent)[ordinal - 1]
+export type TextAccent = 1 | 2 | 3 | 4
+export const textAccent = [
+    null, // https://github.com/riktenx/loot-filters/blob/bec89ccfee8f85fab8c8b1dc9da49f972c2316fb/src/main/java/com/lootfilters/rule/FontType.java#L15
+    'Shadow',
+    'Outline',
+    'None',
+    'Shadow Bold',
+] as const
+
+export const fontFamilyFromFontType = (fontType?: FontType) => {
+    switch (fontType) {
+        case 1:
+            return 'RuneScapeSmall'
+        case 2:
+            return 'RuneScape'
+        case 3:
+            return 'RuneScapeBold'
+        default:
+            return 'RuneScapeSmall'
+    }
 }
 
-export const textAccentOrdinal = (textAccent: TextAccent): number => {
-    return Object.values(TextAccent).indexOf(textAccent) + 1
-}
-export const uiSelectFromOrdinal = (
-    textAccentOrdinal?: number
-): {
-    label: TextAccent
-    value: number
-} | null => {
-    return textAccentOrdinal !== undefined
-        ? {
-              label: textAccentFromOrdinal(textAccentOrdinal),
-              value: textAccentOrdinal,
-          }
-        : null
-}
-
-export enum TextAccent {
-    SHADOW = 'shadow',
-    OUTLINE = 'outline',
-    NONE = 'none',
-    SHADOW_BOLD = 'shadow_bold',
-}
-
-// Enum ordinal needs to match what is supported in the plugin
-
-export const fontTypeOrdinal = (fontType: FontType): number => {
-    return Object.values(FontType).indexOf(fontType)
-}
-
-export const fontTypeFromOrdinal = (ordinal: number): FontType => {
-    return Object.values(FontType)[ordinal]
-}
-export enum FontType {
-    NORMAL = 'Normal',
-    LARGER = 'Larger',
-    BOLD = 'Bold',
-}
+export type FontType = 1 | 2 | 3
+export const fontType = [
+    null, // https://github.com/riktenx/loot-filters/blob/bec89ccfee8f85fab8c8b1dc9da49f972c2316fb/src/main/java/com/lootfilters/rule/TextAccent.java#L18
+    'Small',
+    'Normal',
+    'Bold',
+] as const
 
 /**
  * @pattern ^#([0-9a-fA-F]{8})$
@@ -128,9 +114,9 @@ export type StyleInput = Omit<FilterModuleInput<'style'>, 'default'> & {
         textColor: ArgbHexColor
         backgroundColor: ArgbHexColor
         borderColor: ArgbHexColor
-        textAccent: number // TextAccent;
+        textAccent: TextAccent
         textAccentColor: ArgbHexColor
-        fontType: number // FontType;
+        fontType: FontType
         showLootbeam: boolean
         lootbeamColor: ArgbHexColor
         showValue: boolean

--- a/src/types/InputsSpec.ts
+++ b/src/types/InputsSpec.ts
@@ -74,12 +74,26 @@ export type IncludeExcludeListInput = Omit<
 
 // Enum ordinal needs to match what is supported in the plugin
 export const textAccentFromOrdinal = (ordinal: number): TextAccent => {
-    return Object.values(TextAccent)[ordinal]
+    return Object.values(TextAccent)[ordinal - 1]
 }
 
 export const textAccentOrdinal = (textAccent: TextAccent): number => {
-    return Object.values(TextAccent).indexOf(textAccent)
+    return Object.values(TextAccent).indexOf(textAccent) + 1
 }
+export const uiSelectFromOrdinal = (
+    textAccentOrdinal?: number
+): {
+    label: TextAccent
+    value: number
+} | null => {
+    return textAccentOrdinal !== undefined
+        ? {
+              label: textAccentFromOrdinal(textAccentOrdinal),
+              value: textAccentOrdinal,
+          }
+        : null
+}
+
 export enum TextAccent {
     SHADOW = 'shadow',
     OUTLINE = 'outline',


### PR DESCRIPTION
note the "shadow" in the text accent field and properly rendered global default preview

![image](https://github.com/user-attachments/assets/6926ebc6-4f03-445d-bd11-f2476781348e)
