### PR TITLE
add support for relative filter modules

### DIFF
--- a/src/types/ModularFilterSpec.ts
+++ b/src/types/ModularFilterSpec.ts
@@ -21,9 +21,7 @@ export type FilterSource =
  */
 export type ModuleSource =
     | {
-          name: string
-          relativeModuleJsonUrl: string
-          relativeModuleRs2fUrl: string
+          modulePath: string
       }
     | {
           name: string
@@ -56,6 +54,8 @@ export type FilterModule = {
     subtitle?: string
     // Long text displayed in the UI _inside_ the accordion
     description?: string
+    // Relative path to the rs2f file
+    rs2fPath?: string
     // default to true
     enabled?: boolean
     inputs: Input[]

--- a/src/types/ModularFilterSpec.ts
+++ b/src/types/ModularFilterSpec.ts
@@ -22,6 +22,11 @@ export type FilterSource =
 export type ModuleSource =
     | {
           name: string
+          relativeModuleJsonUrl: string
+          relativeModuleRs2fUrl: string
+      }
+    | {
+          name: string
           moduleJsonUrl: string
           moduleRs2fUrl: string
       }

--- a/src/utils/modularFilterLoader.ts
+++ b/src/utils/modularFilterLoader.ts
@@ -108,7 +108,7 @@ export const loadFilter = async (
                     return module
                 } else {
                     throw new Error(
-                        `Invalid module source '${JSON.stringify(moduleSource)}', no moduleJson or moduleJsonUrl`
+                        `Invalid module source '${JSON.stringify(moduleSource)}', no moduleJson or moduleJsonUrl, no relativeModuleJsonUrl or relativeModuleRs2fUrl`
                     )
                 }
             }

--- a/src/utils/modularFilterLoader.ts
+++ b/src/utils/modularFilterLoader.ts
@@ -79,21 +79,25 @@ export const loadFilter = async (
                     validateModule(module)
                     return module
                 } else if (
-                    'relativeModuleJsonUrl' in moduleSource &&
-                    moduleSource.relativeModuleJsonUrl &&
-                    'relativeModuleRs2fUrl' in moduleSource &&
-                    moduleSource.relativeModuleRs2fUrl &&
+                    'modulePath' in moduleSource &&
+                    moduleSource.modulePath &&
                     'filterUrl' in source &&
                     source.filterUrl
                 ) {
                     const baseUrl = trimUrl(source.filterUrl)
-                    const moduleJsonUrl = `${baseUrl}/${moduleSource.relativeModuleJsonUrl}`
-                    const moduleRs2fUrl = `${baseUrl}/${moduleSource.relativeModuleRs2fUrl}`
+                    const moduleJsonUrl = `${baseUrl}/${moduleSource.modulePath}`
 
                     const moduleJsonResponse = await fetch(moduleJsonUrl)
                     const moduleJson =
                         (await moduleJsonResponse.json()) as FilterModule
 
+                    if (!moduleJson.rs2fPath) {
+                        throw new Error(
+                            `Module ${moduleJson.name} has no rs2fPath`
+                        )
+                    }
+                    const moduleBaseUrl = trimUrl(moduleJsonUrl)
+                    const moduleRs2fUrl = `${moduleBaseUrl}/${moduleJson.rs2fPath}`
                     const moduleRs2fResponse = await fetch(moduleRs2fUrl)
                     const moduleRs2fText = await moduleRs2fResponse.text()
 
@@ -108,7 +112,7 @@ export const loadFilter = async (
                     return module
                 } else {
                     throw new Error(
-                        `Invalid module source '${JSON.stringify(moduleSource)}', no moduleJson or moduleJsonUrl, no relativeModuleJsonUrl or relativeModuleRs2fUrl`
+                        `Invalid module source '${JSON.stringify(moduleSource)}', no moduleJson or moduleJsonUrl, no modulePath`
                     )
                 }
             }


### PR DESCRIPTION
example filter
https://github.com/typical-whack/loot-filters-modules/blob/main/simple-relative-filter.json

example relative filter file:
```
{
    "type": "filter",
    "name": "Simple filter to test relative module references",
    "description": "WOW!",
    "modules": [
        {
            "modulePath": "global/mod_global.json"
        },
        {
            "modulePath": "item_values/mod_item_values.json"
        },
        {
            "modulePath": "_terminate/mod_terminate.json"
        }
    ]
}
```

with an example module json:
```
{
    "name": "Global defaults",
    "rs2fPath": "mod_global.rs2f",
    "inputs": []
}
```
or less cache monet:
```
{
    "name": "Global defaults",
    "rs2fPath": "https://raw.githubusercontent.com/typical-whack/loot-filters-modules/refs/heads/main/global/mod_global.rs2f",
    "inputs": []
}

```