### PR TITLE
pin filterscape version now that it has relative modules

### DIFF
--- a/src/components/FilterSelector.tsx
+++ b/src/components/FilterSelector.tsx
@@ -18,7 +18,7 @@ import { Option, UISelect } from './inputs/UISelect'
 const COMMON_FILTERS = [
     {
         name: 'FilterScape - An all in one filter for mains',
-        url: 'https://raw.githubusercontent.com/riktenx/filterscape/refs/heads/main/index.json',
+        url: 'https://raw.githubusercontent.com/riktenx/filterscape/b0e3e9dcb9dacda328f62d973ad37ff12b4102e3/index.json',
     },
     {
         name: "Joe's Filter for Persnickety Players",


### PR DESCRIPTION
This should mean that this link will always resolve to the same filter