### PR TITLE
list diff migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+src/default-local-state.json

--- a/src/components/inputs/BooleanInputComponent.tsx
+++ b/src/components/inputs/BooleanInputComponent.tsx
@@ -27,7 +27,11 @@ export const BooleanInputComponent: React.FC<{
             checked={currentSetting}
             onChange={(event) => {
                 const value = event.target.checked
-                setFilterConfiguration(activeFilterId, input.macroName, value)
+                setFilterConfiguration<BooleanInput>(
+                    activeFilterId,
+                    input.macroName,
+                    value
+                )
             }}
         />
     )

--- a/src/components/inputs/EnumInputComponent.tsx
+++ b/src/components/inputs/EnumInputComponent.tsx
@@ -1,6 +1,7 @@
 import { useUiStore } from '../../store/store'
-import { EnumListInput } from '../../types/InputsSpec'
+import { EnumListInput, ListDiff } from '../../types/InputsSpec'
 import { FilterId, UiFilterModule } from '../../types/ModularFilterSpec'
+import { applyDiff, convertToListDiff } from '../../utils/ListDiffUtils'
 import { Option, UISelect } from './UISelect'
 
 export const EnumInputComponent: React.FC<{
@@ -15,9 +16,11 @@ export const EnumInputComponent: React.FC<{
         (state) => state.setFilterConfiguration
     )
 
-    const currentSetting: string[] =
-        (activeConfig?.inputConfigs?.[input.macroName] as string[]) ??
-        input.default
+    const configuredDiff = activeConfig?.inputConfigs?.[input.macroName] as
+        | ListDiff
+        | undefined
+
+    const currentSetting = applyDiff(input.default, configuredDiff)
 
     const options: Option<string>[] = input.enum.map((enumValue) => {
         if (typeof enumValue === 'string') {
@@ -52,7 +55,10 @@ export const EnumInputComponent: React.FC<{
                 setFilterConfiguration(
                     activeFilterId,
                     input.macroName,
-                    newValue ? newValue.map((option) => option.value) : []
+                    convertToListDiff(
+                        newValue ? newValue.map((option) => option.value) : [],
+                        input.default
+                    )
                 )
             }}
             multiple

--- a/src/components/inputs/IncludeExcludeListInputComponent.tsx
+++ b/src/components/inputs/IncludeExcludeListInputComponent.tsx
@@ -1,7 +1,12 @@
 import { Box } from '@mui/material'
 import { useUiStore } from '../../store/store'
-import { IncludeExcludeListInput, ListOption } from '../../types/InputsSpec'
+import {
+    IncludeExcludeListInput,
+    ListDiff,
+    ListOption,
+} from '../../types/InputsSpec'
 import { FilterId, UiFilterModule } from '../../types/ModularFilterSpec'
+import { applyDiff, convertToListDiff } from '../../utils/ListDiffUtils'
 import { Option, UISelect } from './UISelect'
 
 export const IncludeExcludeListInputComponent: React.FC<{
@@ -17,14 +22,22 @@ export const IncludeExcludeListInputComponent: React.FC<{
         (state) => state.filterConfigurations[activeFilterId]
     )
 
-    const currentIncludes =
-        (activeConfig?.inputConfigs?.[input.macroName.includes] as
-            | string[]
-            | undefined) ?? input.default.includes
-    const currentExcludes =
-        (activeConfig?.inputConfigs?.[input.macroName.excludes] as
-            | string[]
-            | undefined) ?? input.default.excludes
+    const configuredIncludeDiff = activeConfig?.inputConfigs?.[
+        input.macroName.includes
+    ] as ListDiff | undefined
+
+    const configuredExcludeDiff = activeConfig?.inputConfigs?.[
+        input.macroName.excludes
+    ] as ListDiff | undefined
+
+    const currentIncludes = applyDiff(
+        input.default.includes,
+        configuredIncludeDiff
+    )
+    const currentExcludes = applyDiff(
+        input.default.excludes,
+        configuredExcludeDiff
+    )
 
     const includeOptions: Option[] = input.default.includes.map(
         (option: string | ListOption) => {
@@ -76,10 +89,11 @@ export const IncludeExcludeListInputComponent: React.FC<{
                     const includes = ((newValue as Option[]) || []).map(
                         (option) => option.value
                     )
+
                     setFilterConfiguration(
                         activeFilterId,
                         input.macroName.includes,
-                        includes
+                        convertToListDiff(includes, input.default.includes)
                     )
                 }}
             />
@@ -110,7 +124,7 @@ export const IncludeExcludeListInputComponent: React.FC<{
                     setFilterConfiguration(
                         activeFilterId,
                         input.macroName.excludes,
-                        excludes
+                        convertToListDiff(excludes, input.default.excludes)
                     )
                 }}
             />

--- a/src/components/inputs/StringListInputComponent.tsx
+++ b/src/components/inputs/StringListInputComponent.tsx
@@ -1,6 +1,7 @@
 import { useUiStore } from '../../store/store'
-import { ListOption, StringListInput } from '../../types/InputsSpec'
+import { ListDiff, ListOption, StringListInput } from '../../types/InputsSpec'
 import { FilterId, UiFilterModule } from '../../types/ModularFilterSpec'
+import { applyDiff, convertToListDiff } from '../../utils/ListDiffUtils'
 import { Option, UISelect } from './UISelect'
 
 export const StringListInputComponent: React.FC<{
@@ -16,10 +17,11 @@ export const StringListInputComponent: React.FC<{
         (state) => state.filterConfigurations[activeFilterId]
     )
 
-    const currentValues =
-        (activeConfig?.inputConfigs?.[input.macroName] as
-            | string[]
-            | undefined) ?? input.default
+    const configuredDiff = activeConfig?.inputConfigs?.[input.macroName] as
+        | ListDiff
+        | undefined
+
+    const currentValues = applyDiff(input.default, configuredDiff)
 
     const options: Option[] = input.default.map(
         (option: string | ListOption) => {
@@ -56,7 +58,11 @@ export const StringListInputComponent: React.FC<{
                 const values = ((newValue as Option[]) || []).map(
                     (option) => option.value
                 )
-                setFilterConfiguration(activeFilterId, input.macroName, values)
+                setFilterConfiguration(
+                    activeFilterId,
+                    input.macroName,
+                    convertToListDiff(values, input.default)
+                )
             }}
         />
     )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
 import './styles/styles.css'
@@ -9,6 +8,17 @@ try {
 } catch {
     console.warn('Could not load build info, using default')
 }
+
+try {
+    const localState = localStorage.getItem('modular-filter-storage')
+    if (!localState) {
+        const defaultLocalState = require('./default-local-state.json')
+        localStorage.setItem(
+            'modular-filter-storage',
+            JSON.stringify(defaultLocalState)
+        )
+    }
+} catch {}
 
 const container = document.getElementById('root')
 if (!container) throw new Error('Failed to find the root element')

--- a/src/types/InputsSpec.ts
+++ b/src/types/InputsSpec.ts
@@ -1,3 +1,5 @@
+import { StyleConfig } from '../components/inputs/StyleInputHelpers'
+
 // Don't export this, just use FilterType
 const filterTypes = {
     boolean: 'boolean',
@@ -19,7 +21,39 @@ export type Input =
     | StyleInput
     | TextInput
 export type FilterType = keyof typeof filterTypes
-export type InputDefault<I extends Input> = I['default']
+export type InputDefault<I extends Input> = I extends NumberInput
+    ? number
+    : I extends BooleanInput
+      ? boolean
+      : I extends StringListInput
+        ? string[] | ListOption[]
+        : I extends EnumListInput
+          ? string[]
+          : I extends IncludeExcludeListInput
+            ? IncludeExcludeListInputDefaults
+            : I extends StyleInput
+              ? Partial<StyleConfig>
+              : I extends TextInput
+                ? string
+                : never
+
+export type ListDiff = {
+    added: string[]
+    removed: string[]
+}
+
+export type InputConfig<I extends Input> =
+    I extends Exclude<
+        Input,
+        StringListInput | EnumListInput | IncludeExcludeListInput | StyleInput
+    >
+        ? InputDefault<I>
+        : I extends StringListInput | EnumListInput | IncludeExcludeListInput
+          ? ListDiff
+          : I extends StyleInput
+            ? Partial<StyleConfig>
+            : never
+
 export type ModuleName = string
 export type MacroName = string
 

--- a/src/types/ModularFilterSpec.ts
+++ b/src/types/ModularFilterSpec.ts
@@ -1,4 +1,4 @@
-import { Input, InputDefault, MacroName } from './InputsSpec'
+import { Input, InputConfig, InputDefault, MacroName } from './InputsSpec'
 
 // ### ### ### ### ###
 //
@@ -78,7 +78,7 @@ export type ModularFilterConfiguration = {
 export type ModularFilterConfigurationV2 = {
     enabledModules: { [key: ModuleId]: boolean }
     inputConfigs: {
-        [key: MacroName]: Partial<InputDefault<Input>>
+        [key: MacroName]: InputConfig<Input>
     }
 }
 

--- a/src/utils/ListDiffUtils.ts
+++ b/src/utils/ListDiffUtils.ts
@@ -1,0 +1,92 @@
+import { ListDiff, ListOption } from '../types/InputsSpec'
+
+export const EMPTY_DIFF: ListDiff = {
+    added: [],
+    removed: [],
+}
+
+export const applyDiff = (
+    list: (string | ListOption)[],
+    diff: ListDiff | undefined
+): (string | ListOption)[] => {
+    if (!diff) {
+        return list
+    }
+
+    let realDiff = diff
+    if (Array.isArray(diff)) {
+        realDiff = convertToListDiff(diff, list)
+    }
+
+    return list
+        .filter((item: any) => {
+            if (typeof item === 'string') {
+                return !realDiff.removed.includes(item)
+            } else if (typeof item === 'object' && 'value' in item) {
+                return !realDiff.removed.includes(item.value)
+            }
+            return false
+        })
+        .concat(realDiff.added)
+}
+
+const listContains = (list: (string | ListOption)[], item: string) => {
+    if (list.length === 0) {
+        return false
+    }
+    for (const listItem of list) {
+        if (typeof listItem === 'string') {
+            if (listItem === item) {
+                return true
+            }
+        } else {
+            if (listItem.value === item) {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+export const convertToListDiff = (
+    valuesToDiff: (string | ListOption)[],
+    inputDefaults: (string | ListOption)[]
+): ListDiff => {
+    if (inputDefaults.length === 0) {
+        return {
+            added: convertOptionsToStrings(valuesToDiff),
+            removed: [],
+        }
+    }
+
+    const added = convertOptionsToStrings(
+        valuesToDiff.filter(
+            (item) =>
+                !listContains(
+                    inputDefaults,
+                    typeof item === 'string' ? item : item.value
+                )
+        )
+    )
+
+    const removed = inputDefaults
+        .map((item) => {
+            if (typeof item === 'string') {
+                return item
+            }
+            return item.value
+        })
+        .filter((item) => !listContains(valuesToDiff, item))
+    return { added, removed }
+}
+
+export const convertOptionsToStrings = (
+    list: (string | ListOption)[]
+): string[] => {
+    return list.map((item) => {
+        if (typeof item === 'string') {
+            return item
+        }
+        return item.value
+    })
+}


### PR DESCRIPTION
@typical-whack / @Omniforce 

could I get a review here 🙃

TL;DR goal is to:
1. Migrate stored `string[]` data for list configurations => `{added: string[], removed: string[]}` 
2. Update inputs to actually write said data

Things that happened along the way:
1. The type of a default value for an input is no longer 1:1 with what's stored in config (lists are now different) so I added type stuff for that

2. a whole bunch of list utils 