### PR TITLE
debug page improvements; bugfixes to linking filter configs

### DIFF
--- a/packages/ui/src/components/AppHeader.tsx
+++ b/packages/ui/src/components/AppHeader.tsx
@@ -28,13 +28,13 @@ export const AppHeader: React.FC = () => {
                 }}
             >
                 <Typography variant="h4" color="primary">
-                    Loot Filter Builder
+                    FilterScape.xyz
                     <Typography
                         sx={{ paddingLeft: '1em', display: 'inline-block' }}
                         gutterBottom
                     >
                         <span style={{ color: colors.rsYellow }}>
-                            A LootFilter builder for{' '}
+                            A LootFilter configuration tool for{' '}
                             <Link
                                 style={{
                                     color: colors.rsYellow,

--- a/packages/ui/src/components/FilterSelector.tsx
+++ b/packages/ui/src/components/FilterSelector.tsx
@@ -310,27 +310,25 @@ export const FilterSelector: React.FC<{ reloadOnChange?: boolean }> = ({
                                     return
                                 }
 
-                                createLink(
-                                    activeFilter,
-                                    activeFilterConfig
-                                ).then((link) =>
-                                    navigator.clipboard
-                                        .writeText(link)
-                                        .then(() => {
-                                            addAlert({
-                                                children:
-                                                    'Filter link copied to clipboard',
-                                                severity: 'success',
+                                createLink(activeFilter, activeFilterConfig)
+                                    .then((link) => {
+                                        return navigator.clipboard
+                                            .writeText(link)
+                                            .then(() => {
+                                                addAlert({
+                                                    children:
+                                                        'Filter link copied to clipboard',
+                                                    severity: 'success',
+                                                })
                                             })
+                                    })
+                                    .catch((error) => {
+                                        console.error(error)
+                                        addAlert({
+                                            children: `Failed to copy filter link to clipboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                                            severity: 'error',
                                         })
-                                        .catch((error) => {
-                                            addAlert({
-                                                children:
-                                                    'Failed to copy filter link to clipboard',
-                                                severity: 'error',
-                                            })
-                                        })
-                                )
+                                    })
                             }}
                         >
                             <ListItemIcon>

--- a/packages/ui/src/components/inputs/BooleanInputComponent.tsx
+++ b/packages/ui/src/components/inputs/BooleanInputComponent.tsx
@@ -11,8 +11,6 @@ export const BooleanInputComponent: React.FC<{
     onChange: (boolean: boolean) => void
     readonly: boolean
 }> = ({ input, config, onChange, readonly }) => {
-    console.log('boolean input', input, 'config', config)
-
     const currentSetting = BooleanInputDefaultSpec.parse(
         config?.inputConfigs?.[input.macroName] ?? input.default
     )

--- a/packages/ui/src/pages/EditLoadedFilterPage.tsx
+++ b/packages/ui/src/pages/EditLoadedFilterPage.tsx
@@ -67,16 +67,13 @@ export const EditorLoadedFilterPage: React.FC = () => {
             : 'prefixRs2f'
     )
     const setContent = (id: string, content: string) => {
-        console.log('setContent', id, content)
         if (id === 'filterRs2f') {
             const modules = parseModules(content)
-            console.log('modules', modules)
             const newFilter = {
                 ...filters[filterId],
                 ...(modules.modules ? { modules: modules.modules } : {}),
                 rs2f: content,
             }
-            console.log('newFilter', newFilter)
             updateFilter(newFilter)
         } else if (id === 'prefixRs2f' || id === 'suffixRs2f') {
             setFilterConfiguration(filterId, {

--- a/packages/ui/src/pages/ImportPage.tsx
+++ b/packages/ui/src/pages/ImportPage.tsx
@@ -46,18 +46,17 @@ export const ImportPage: React.FC = () => {
             .then(({ filterUrl, config }) => {
                 setFilterUrl(filterUrl)
                 setFilterConfig(config)
+                console.log('filterUrl', filterUrl)
+                console.log('config', config)
                 return fetch(filterUrl)
             })
             .then((res) => {
-                console.log('res', res)
                 return res.text()
             })
             .then((text: string) => {
-                console.log('text', text)
                 return parse(text)
             })
             .then((parsed: ParseResult) => {
-                console.log('parsed', parsed)
                 setParsedFilter(parsed)
                 setError(null)
                 setLoadingFilter(false)
@@ -68,8 +67,6 @@ export const ImportPage: React.FC = () => {
                 setLoadingFilter(false)
             })
     }, [])
-    console.log('filterUrl', filterUrl)
-    console.log('parsedFilter', parsedFilter)
 
     const errorComponent = error ? (
         <div>

--- a/packages/ui/src/store/migrations/MigrateLegacyData.tsx
+++ b/packages/ui/src/store/migrations/MigrateLegacyData.tsx
@@ -17,7 +17,6 @@ export const legacyFilterUrls: Record<string, string> = {
 
 const LAST_MIGRATION_DATE = '2025-04-19'
 export const requiresMigration = () => {
-    console.log('Checking for migration')
     const legacyData = localStorage.getItem('modular-filter-storage')
 
     if (!legacyData) {
@@ -27,18 +26,12 @@ export const requiresMigration = () => {
     const migrated = localStorage.getItem('modular-filter-storage-migrated')
 
     if (!migrated) {
-        console.log('No migration date found, requiring migration')
         return true
     }
-
-    console.log('Migration date found:', migrated)
 
     try {
         const date = Date.parse(migrated)
         if (date < new Date(LAST_MIGRATION_DATE).getTime() || isNaN(date)) {
-            console.log(
-                `Migration date is before ${LAST_MIGRATION_DATE}, requiring migration`
-            )
             return true
         }
         return false
@@ -49,7 +42,6 @@ export const requiresMigration = () => {
 }
 
 export const MigrateLegacyData: React.FC = () => {
-    console.log('Migrating legacy data')
     const { setFilterConfiguration } = useFilterConfigStore()
     const { filters, updateFilter } = useFilterStore()
 

--- a/packages/ui/src/utils/file.ts
+++ b/packages/ui/src/utils/file.ts
@@ -14,7 +14,7 @@ export const downloadFile = (file: File) => {
     }
 }
 
-const keys = [
+export const localStorageKeys = [
     'background-image-selected',
     'filter-store',
     'modular-filter-storage',
@@ -23,7 +23,7 @@ const keys = [
 ]
 export const localState = () => {
     return Object.fromEntries(
-        keys
+        localStorageKeys
             .map((key) => {
                 return [key, localStorage.getItem(key)]
             })

--- a/packages/ui/src/utils/link.ts
+++ b/packages/ui/src/utils/link.ts
@@ -13,6 +13,10 @@ export const createLink = (
         config: config,
     }
 
+    if (!data.filterUrl) {
+        return Promise.reject(new Error('This filter has no source URL'))
+    }
+
     const component = compressToEncodedURIComponent(JSON.stringify(data))
 
     if (component.length >= 15 * 1024) {
@@ -31,6 +35,7 @@ export const parseComponent = async (
     config: FilterConfiguration
 }> => {
     const data = decompressFromEncodedURIComponent(component)
+    console.log('data', data)
     const parsedData = JSON.parse(data)
     return parsedData
 }


### PR DESCRIPTION
1. Put the site name in the app header.
2. Update Debug page to show the local storage state - firefox's local storage browsing is kinda ass for development compared to chrome so ... this'll be easier for me to do dev with.

3. Some related styling changes to `/debug` 
4. Fix bug where you could create link to a filter without a filter URL causing import to break.
5. rip out a bunch of console.logs 