### PR TITLE
actually copy data to clipboard + allow pasting from clipboard into stringlist

### DIFF
--- a/packages/ui/src/components/inputs/CopyInputSettings.tsx
+++ b/packages/ui/src/components/inputs/CopyInputSettings.tsx
@@ -25,10 +25,23 @@ export const CopyInputSettings: React.FC<{
     const doCopy = useCallback(() => {
         console.log('doCopy', configToCopy)
         setSettingsCopy(input, configToCopy)
-        addAlert({
-            children: `${input.label} ${input.type} settings copied to clipboard`,
-            severity: 'success',
-        })
+        const formattedConfig = Array.isArray(configToCopy)
+            ? configToCopy.join(', ')
+            : JSON.stringify(configToCopy).replace(/[\[\]"]/g, '')
+        navigator.clipboard
+            .writeText(formattedConfig)
+            .then(() => {
+                addAlert({
+                    children: `${input.label} ${input.type} settings copied to clipboard`,
+                    severity: 'success',
+                })
+            })
+            .catch(() => {
+                addAlert({
+                    children: `Failed to copy ${input.label} ${input.type} settings to clipboard`,
+                    severity: 'error',
+                })
+            })
     }, [configToCopy, onChange])
 
     return (

--- a/packages/ui/src/components/inputs/CopyInputSettings.tsx
+++ b/packages/ui/src/components/inputs/CopyInputSettings.tsx
@@ -25,9 +25,7 @@ export const CopyInputSettings: React.FC<{
     const doCopy = useCallback(() => {
         console.log('doCopy', configToCopy)
         setSettingsCopy(input, configToCopy)
-        const formattedConfig = Array.isArray(configToCopy)
-            ? configToCopy.join(', ')
-            : JSON.stringify(configToCopy).replace(/[\[\]"]/g, '')
+        const formattedConfig = JSON.stringify(configToCopy)
         navigator.clipboard
             .writeText(formattedConfig)
             .then(() => {

--- a/packages/ui/src/components/inputs/EnumInputComponent.tsx
+++ b/packages/ui/src/components/inputs/EnumInputComponent.tsx
@@ -5,14 +5,11 @@ import {
     ListDiff,
     ListDiffSpec,
 } from '../../parsing/UiTypesSpec'
-import { useAlertStore } from '../../store/alerts'
-import { useSettingsCopyStore } from '../../store/settingsCopyStore'
 import {
     applyDiff,
     convertToListDiff,
     EMPTY_DIFF,
 } from '../../utils/ListDiffUtils'
-import { CopyInputSettings } from './CopyInputSettings'
 import { Option, UISelect } from './UISelect'
 
 export const EnumInputComponent: React.FC<{
@@ -24,9 +21,6 @@ export const EnumInputComponent: React.FC<{
     const configuredDiff = ListDiffSpec.optional()
         .default(EMPTY_DIFF)
         .parse(config?.inputConfigs?.[input.macroName])
-    const { copiedInput, pasteableConfig, setSettingsCopy } =
-        useSettingsCopyStore()
-    const { addAlert } = useAlertStore()
 
     const currentSetting = applyDiff(input.default, configuredDiff)
 
@@ -61,16 +55,6 @@ export const EnumInputComponent: React.FC<{
                 <Typography variant="h6" color="primary">
                     {input.label}
                 </Typography>
-                <CopyInputSettings
-                    input={input}
-                    configToCopy={currentSetting.map((v) => {
-                        if (typeof v === 'string') {
-                            return v
-                        }
-                        return v.value
-                    })}
-                    onChange={onChange}
-                />
             </div>
             <UISelect<string>
                 disabled={readonly}

--- a/packages/ui/src/components/inputs/StringListInputComponent.tsx
+++ b/packages/ui/src/components/inputs/StringListInputComponent.tsx
@@ -77,13 +77,13 @@ export const StringListInputComponent: React.FC<{
                         (option) => option.value
                     )
                     const splitValues = values
-                        .map((v) => {
+                        .flatMap((v) => {
                             if (v.startsWith('[') && v.endsWith(']')) {
                                 return v.slice(1, -1)
                             }
                             return v
                         })
-                        .map((v) =>
+                        .flatMap((v) =>
                             v
                                 .split(',')
                                 .map((v) => v.trim())
@@ -94,7 +94,6 @@ export const StringListInputComponent: React.FC<{
                                         : v
                                 )
                         )
-                        .flat()
                     onChange(convertToListDiff(splitValues, input.default))
                 }}
             />

--- a/packages/ui/src/components/inputs/StringListInputComponent.tsx
+++ b/packages/ui/src/components/inputs/StringListInputComponent.tsx
@@ -76,7 +76,15 @@ export const StringListInputComponent: React.FC<{
                     const values = ((newValue as Option[]) || []).map(
                         (option) => option.value
                     )
-                    onChange(convertToListDiff(values, input.default))
+                    const splitValues = values
+                        .map((v) =>
+                            v
+                                .split(',')
+                                .map((v) => v.trim())
+                                .filter((v) => v)
+                        )
+                        .flat()
+                    onChange(convertToListDiff(splitValues, input.default))
                 }}
             />
         </div>

--- a/packages/ui/src/components/inputs/StringListInputComponent.tsx
+++ b/packages/ui/src/components/inputs/StringListInputComponent.tsx
@@ -77,6 +77,12 @@ export const StringListInputComponent: React.FC<{
                         (option) => option.value
                     )
                     const splitValues = values
+                        .map((v) => {
+                            if (v.startsWith('[') && v.endsWith(']')) {
+                                return v.slice(1, -1)
+                            }
+                            return v
+                        })
                         .map((v) =>
                             v
                                 .split(',')

--- a/packages/ui/src/components/inputs/StringListInputComponent.tsx
+++ b/packages/ui/src/components/inputs/StringListInputComponent.tsx
@@ -82,6 +82,11 @@ export const StringListInputComponent: React.FC<{
                                 .split(',')
                                 .map((v) => v.trim())
                                 .filter((v) => v)
+                                .map((v) =>
+                                    v.startsWith('"') && v.endsWith('"')
+                                        ? v.slice(1, -1)
+                                        : v
+                                )
                         )
                         .flat()
                     onChange(convertToListDiff(splitValues, input.default))

--- a/packages/ui/src/components/inputs/StringListInputComponent.tsx
+++ b/packages/ui/src/components/inputs/StringListInputComponent.tsx
@@ -14,6 +14,25 @@ import {
 import { CopyInputSettings } from './CopyInputSettings'
 import { Option, UISelect } from './UISelect'
 
+const parseValues = (values: string[]): string[] => {
+    return values
+        .flatMap((v) => {
+            if (v.startsWith('[') && v.endsWith(']')) {
+                return v.slice(1, -1)
+            }
+            return v
+        })
+        .flatMap((v) =>
+            v
+                .split(',')
+                .map((v) => v.trim())
+                .filter((v) => v)
+                .map((v) =>
+                    v.startsWith('"') && v.endsWith('"') ? v.slice(1, -1) : v
+                )
+        )
+}
+
 export const StringListInputComponent: React.FC<{
     input: StringListInput
     config: FilterConfiguration
@@ -76,24 +95,7 @@ export const StringListInputComponent: React.FC<{
                     const values = ((newValue as Option[]) || []).map(
                         (option) => option.value
                     )
-                    const splitValues = values
-                        .flatMap((v) => {
-                            if (v.startsWith('[') && v.endsWith(']')) {
-                                return v.slice(1, -1)
-                            }
-                            return v
-                        })
-                        .flatMap((v) =>
-                            v
-                                .split(',')
-                                .map((v) => v.trim())
-                                .filter((v) => v)
-                                .map((v) =>
-                                    v.startsWith('"') && v.endsWith('"')
-                                        ? v.slice(1, -1)
-                                        : v
-                                )
-                        )
+                    const splitValues = parseValues(values)
                     onChange(convertToListDiff(splitValues, input.default))
                 }}
             />


### PR DESCRIPTION
this is only really useful when copying data out of the website and into something like text editors directly

it also means that copying a stringlist and pasting that stringlist into a stringlist input will actually work (if a user doesnt use the paste button) (depends on the comma delim values change from here: https://github.com/Kaqemeex/loot-filters-ui/pull/164)

this wont really do anything useful for copying anything other than stringlists so maybe this should ONLY work for those inputs?

## copy to clipboard

here is a string list input:
![image](https://github.com/user-attachments/assets/af786bf0-0308-4b7b-b108-ed1bc52215d3)
and its copied to clipboard value:
```
["broken arrow","old boot"]
```

## paste from clipboard (for stringlist)
### handling unquoted input
before pressing enter:
![image](https://github.com/user-attachments/assets/2522704f-559d-4fdc-9fb2-b93c4d45af36)
after pressing enter:
![image](https://github.com/user-attachments/assets/d5c668b3-c3bf-4f51-b383-f206f563e715)
### handling quoted input
before pressing enter:
![image](https://github.com/user-attachments/assets/d582c73b-7c88-491e-8dab-1ec2d5d4291e)
after pressing enter:
![image](https://github.com/user-attachments/assets/570319ad-5d26-4a9c-8713-a88583c302e0)
### handling leading [ and trailing ]
before pressing enter:
![image](https://github.com/user-attachments/assets/2f910289-bf4b-46d4-bc60-d22831a4fd4f)
after pressing enter:
![image](https://github.com/user-attachments/assets/ebb05500-c02b-4b83-96d3-964195f18819)