### PR TITLE
filter udpate modal

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,7 +6,7 @@ import { AppHeader } from './components/AppHeader'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { FilterSelector } from './components/FilterSelector'
 import { initImages } from './images/osrs/imageUtils'
-import { FilterTabs } from './pages/CustomizeFilterPage'
+import { CustomizeFilterPageBody } from './pages/CustomizeFilterPage'
 import { DebugPage } from './pages/DebugPage'
 import { EditorLoadedFilterPage } from './pages/EditLoadedFilterPage'
 import { ImportPage } from './pages/ImportPage'
@@ -87,7 +87,7 @@ export const App = () => {
                                             />
                                         }
                                     >
-                                        <FilterTabs />
+                                        <CustomizeFilterPageBody />
                                     </ErrorBoundary>
                                 }
                             />

--- a/packages/ui/src/components/FilterSelector.tsx
+++ b/packages/ui/src/components/FilterSelector.tsx
@@ -85,8 +85,7 @@ const UpdateAvailableDialog: React.FC<{
         filterUrl != null &&
         filterUrl != undefined &&
         (filterUrl?.startsWith(
-            // 'https://raw.githubusercontent.com/riktenx/filterscape'
-            'asdf'
+            'https://raw.githubusercontent.com/riktenx/filterscape'
         ) ||
             filterUrl?.startsWith(
                 'https://raw.githubusercontent.com/typical-whack/loot-filters-modules'

--- a/packages/ui/src/pages/CustomizeFilterPage.tsx
+++ b/packages/ui/src/pages/CustomizeFilterPage.tsx
@@ -5,7 +5,7 @@ import { CustomizeTab } from '../components/tabs/CustomizeTab'
 import { useFilterConfigStore } from '../store/filterConfigurationStore'
 import { useFilterStore } from '../store/filterStore'
 
-export const FilterTabs: React.FC = () => {
+export const CustomizeFilterPageBody: React.FC = () => {
     const [activeTab, setActiveTab] = useState(0)
 
     const activeFilter = useFilterStore((state) =>


### PR DESCRIPTION
## For unofficial filters we give the option to update:
<img width="541" alt="Screenshot 2025-04-26 at 11 13 33 PM" src="https://github.com/user-attachments/assets/14b4507a-05f4-46fc-b21f-1a99641f7901" />

## For the 2 flagship ones, updates are automatic, with a reminder to re-import to RuneLite:

This stays up for 5 seconds.

<img width="639" alt="Screenshot 2025-04-26 at 11 12 33 PM" src="https://github.com/user-attachments/assets/787e1a58-3817-42a6-95b1-76d617f8ff29" />

Then we present the user with this.
<img width="637" alt="Screenshot 2025-04-26 at 11 12 38 PM" src="https://github.com/user-attachments/assets/60dc081f-5b34-4f5b-9c11-13c001f7f3ab" />


They can't decline the update - but I wanted to make sure they were aware; hence the synthetic waiting period.
