### PR TITLE
add support for group icons

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -9,15 +9,15 @@ import { initImages } from './images/osrs/imageUtils'
 import { CustomizeFilterPageBody } from './pages/CustomizeFilterPage'
 import { DebugPage } from './pages/DebugPage'
 import { EditorLoadedFilterPage } from './pages/EditLoadedFilterPage'
-import { ImportPage } from './pages/ImportPage'
 import { HelpPage } from './pages/HelpPage'
+import { ImportPage } from './pages/ImportPage'
+import { NewFilterPage } from './pages/NewFilterPage'
 import { useAlertStore } from './store/alerts'
 import {
     MigrateLegacyData,
     requiresMigration,
 } from './store/migrations/MigrateLegacyData'
 import { MuiRsTheme } from './styles/MuiTheme'
-import { NewFilterPage } from './pages/NewFilterPage'
 
 const Page: React.FC<{
     component?: ReactNode

--- a/packages/ui/src/components/tabs/CustomizeTab.tsx
+++ b/packages/ui/src/components/tabs/CustomizeTab.tsx
@@ -19,6 +19,7 @@ import { colors, MuiRsTheme } from '../../styles/MuiTheme'
 
 import SettingsIcon from '@mui/icons-material/Settings'
 import { useSearchParams } from 'react-router-dom'
+import { getIcon, getSprite } from '../../images/osrs/imageUtils'
 import { parseModules } from '../../parsing/parse'
 import {
     BooleanInput,
@@ -286,12 +287,30 @@ const ModuleGroup: React.FC<{
     onChange,
 }) => {
     const groupName = group || 'Default Group'
-    const groupDescription = module.groups.find(
-        (g) => g.name === groupName
-    )?.description
-    const groupExpanded = module.groups.find(
-        (g) => g.name === groupName
-    )?.expanded
+    const groupConfig = module.groups.find((g) => g.name === groupName)
+    const groupDescription = groupConfig?.description
+    const groupExpanded = groupConfig?.expanded
+    const groupIconConfig = groupConfig?.icon
+    const [groupIcon, setGroupIcon] = useState<HTMLImageElement | undefined>(
+        undefined
+    )
+    useEffect(() => {
+        switch (groupIconConfig?.type) {
+            case 'itemId':
+                getIcon(groupIconConfig.itemId, setGroupIcon)
+                break
+            case 'sprite':
+                getSprite(
+                    groupIconConfig.spriteId ?? 0,
+                    groupIconConfig.spriteIndex ?? 0,
+                    setGroupIcon
+                )
+                break
+            default:
+                break
+        }
+    }, [setGroupIcon, groupIconConfig])
+
     const groupPreviews = getPreviewsForGroup({
         module,
         groupName,
@@ -316,7 +335,29 @@ const ModuleGroup: React.FC<{
                     backgroundColor: colors.rsLighterBrown,
                 }}
             >
-                <Typography sx={{ alignSelf: 'center' }}>{group}</Typography>
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                    }}
+                >
+                    {groupIcon && (
+                        <img
+                            style={{
+                                verticalAlign: 'middle',
+                                width: '36px',
+                                height: '36px',
+                                objectFit: 'contain',
+                            }}
+                            src={groupIcon.src}
+                            alt={groupIcon.name}
+                        />
+                    )}
+                    <Typography sx={{ alignSelf: 'center' }}>
+                        {group}
+                    </Typography>
+                </div>
                 <Stack
                     direction="row"
                     sx={{

--- a/packages/ui/src/parsing/FilterTypesSpec.ts
+++ b/packages/ui/src/parsing/FilterTypesSpec.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { IconSpec } from './IconSpec'
 
 export const ModuleSpec = z.object({
     name: z.string().nonempty(),
@@ -12,6 +13,7 @@ export type Module = z.infer<typeof ModuleSpec>
 
 export const GroupSpec = z.object({
     name: z.string().nonempty(),
+    icon: IconSpec.optional(),
     description: z.string().optional(),
     expanded: z.boolean().optional(),
 })

--- a/packages/ui/src/parsing/IconSpec.ts
+++ b/packages/ui/src/parsing/IconSpec.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const IconSpec = z
+    .object({
+        type: z.enum(['none', 'current', 'file', 'sprite', 'itemId']),
+    })
+    .catchall(z.any())
+
+export type Icon = z.infer<typeof IconSpec>
+
+export const IconNoneSpec = IconSpec.extend({
+    type: z.literal('none'),
+})
+export type IconNone = z.infer<typeof IconNoneSpec>
+
+export const IconCurrentSpec = IconSpec.extend({
+    type: z.literal('current'),
+})
+export type IconCurrent = z.infer<typeof IconCurrentSpec>
+
+export const IconFileSpec = IconSpec.extend({
+    type: z.literal('file'),
+    filePath: z.string().optional(),
+})
+export type IconFile = z.infer<typeof IconFileSpec>
+
+export const IconSpriteSpec = IconSpec.extend({
+    type: z.literal('sprite'),
+    spriteId: z.number().optional(),
+    spriteIndex: z.number().optional(),
+})
+export type IconSprite = z.infer<typeof IconSpriteSpec>
+
+export const IconItemIdSpec = IconSpec.extend({
+    type: z.literal('itemId'),
+    itemId: z.number().optional(),
+})
+export type IconItemId = z.infer<typeof IconItemIdSpec>

--- a/packages/ui/src/parsing/UiTypesSpec.ts
+++ b/packages/ui/src/parsing/UiTypesSpec.ts
@@ -5,6 +5,7 @@ import {
     ModuleSpec as FilterSpecModule,
     GroupSpec,
 } from './FilterTypesSpec'
+import { IconSpec } from './IconSpec'
 
 export const InputSpec = FilterSpecInput.extend({
     macroName: z.string().nonempty(),
@@ -72,43 +73,6 @@ export const ArgbHexColorSpec = z
     .max(9)
     .optional()
     .catch('#FF000000')
-
-export const IconSpec = z
-    .object({
-        type: z.enum(['none', 'current', 'file', 'sprite', 'itemId']),
-    })
-    .catchall(z.any())
-
-export type Icon = z.infer<typeof IconSpec>
-
-export const IconNoneSpec = IconSpec.extend({
-    type: z.literal('none'),
-})
-export type IconNone = z.infer<typeof IconNoneSpec>
-
-export const IconCurrentSpec = IconSpec.extend({
-    type: z.literal('current'),
-})
-export type IconCurrent = z.infer<typeof IconCurrentSpec>
-
-export const IconFileSpec = IconSpec.extend({
-    type: z.literal('file'),
-    filePath: z.string().optional(),
-})
-export type IconFile = z.infer<typeof IconFileSpec>
-
-export const IconSpriteSpec = IconSpec.extend({
-    type: z.literal('sprite'),
-    spriteId: z.number().optional(),
-    spriteIndex: z.number().optional(),
-})
-export type IconSprite = z.infer<typeof IconSpriteSpec>
-
-export const IconItemIdSpec = IconSpec.extend({
-    type: z.literal('itemId'),
-    itemId: z.number().optional(),
-})
-export type IconItemId = z.infer<typeof IconItemIdSpec>
 
 export const StyleConfigSpec = z.object({
     textColor: ArgbHexColorSpec.optional(),

--- a/packages/ui/src/parsing/parseGroup.ts
+++ b/packages/ui/src/parsing/parseGroup.ts
@@ -6,6 +6,6 @@ export const parseGroup = (comment: string): Group => {
         comment.indexOf('\n'), // chop the structured declaration
         comment.indexOf('*/')
     )
-    const group = parseYaml(declarationContent)
-    return GroupSpec.parse(group)
+    const groupYaml = parseYaml(declarationContent)
+    return GroupSpec.parse(groupYaml)
 }

--- a/packages/ui/src/parsing/parseInput.ts
+++ b/packages/ui/src/parsing/parseInput.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml } from 'yaml'
 import { InputSpec as FilterSpecInput } from './FilterTypesSpec'
+import { Icon } from './IconSpec'
 import {
     BooleanInputSpec,
     EnumListInputSpec,
@@ -7,10 +8,9 @@ import {
     InputSpec,
     NumberInputSpec,
     StringListInputSpec,
+    StyleConfig,
     StyleInputSpec,
     TextInputSpec,
-    StyleConfig,
-    Icon,
 } from './UiTypesSpec'
 import { TokenType } from './token'
 import { TokenStream, TokenStreamError } from './tokenstream'

--- a/packages/ui/src/utils/render.ts
+++ b/packages/ui/src/utils/render.ts
@@ -1,15 +1,14 @@
+import { Icon } from '../parsing/IconSpec'
 import { parseModules } from '../parsing/parse'
 import {
     Filter,
     FilterConfiguration,
-    Icon,
     ListDiff,
     MacroName,
     Module,
     StyleConfig,
 } from '../parsing/UiTypesSpec'
 import { applyDiff, convertOptionsToStrings, EMPTY_DIFF } from './ListDiffUtils'
-
 export const renderFilter = (
     filter: Filter,
     activeConfig: FilterConfiguration | undefined


### PR DESCRIPTION
branch of my filter to test with:
https://github.com/typical-whack/loot-filters-modules/pull/61

adds support for adding group icons like:
```
/*@ define:group
---
name: Farming seeds
icon: 
  type: itemId
  itemId: 30093
*/
```
and
```
/*@ define:group
---
name: List of alchables
icon: 
  type: sprite
  spriteId: 41
  spriteIndex: 0
*/
```

Current Version is left, Version running this PR is right
![image](https://github.com/user-attachments/assets/e0fb48ac-5722-4b14-a1b8-d4b236fc87a6)
